### PR TITLE
Added support for native debugging through the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM krisfoster/graal-ee-ol-base-debug:21.0.0.2-JDK8
+
+RUN mkdir app
+COPY . /app
+WORKDIR app
+
+RUN make compile

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,11 @@ run:
 
 runJar:
 	java -jar ./build/libs/logback-0.0.1-SNAPSHOT.war
+
+build-docker:
+	docker build \
+		-f Dockerfile \
+		-t logback-test:0.1 .
+
+run-docker:
+	docker run --rm -it -p 8080:8080 logback-test:0.1 /bin/bash

--- a/compile-only.sh
+++ b/compile-only.sh
@@ -28,6 +28,8 @@ echo "Compiling $ARTIFACT with $GRAALVM_VERSION"
 native-image \
   --no-server \
   --no-fallback \
+  -H:Debug=2 \
+  -H:Optimize=0 \
   --install-exit-handlers \
   --enable-all-security-services \
   --verbose \


### PR DESCRIPTION
The base docker image is private, so you will need to share your docker hub details with me in order for me to allow access